### PR TITLE
Pod 1.x

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,4 +3,6 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 inhibit_all_warnings!
 
-pod 'OpenCV', '~> 2.4'
+target 'opencv-facerec' do
+  pod 'OpenCV', '~> 2.4'
+end

--- a/iOS-OpenCV-FaceRec.xcodeproj/project.pbxproj
+++ b/iOS-OpenCV-FaceRec.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0B3EDF519E0775A91EF5568C /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 70A5E7535BA0C31A438E84CE /* libPods.a */; };
 		871018331A841928000CEDBD /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8710181F1A841928000CEDBD /* AppDelegate.m */; };
 		871018341A841928000CEDBD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 871018201A841928000CEDBD /* LaunchScreen.xib */; };
 		871018351A841928000CEDBD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 871018221A841928000CEDBD /* Main.storyboard */; };
@@ -21,10 +20,13 @@
 		8710183D1A841928000CEDBD /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 8710182E1A841928000CEDBD /* main.m */; };
 		8710183E1A841928000CEDBD /* UIImage+OpenCV.mm in Sources */ = {isa = PBXBuildFile; fileRef = 871018301A841928000CEDBD /* UIImage+OpenCV.mm */; };
 		8710183F1A841928000CEDBD /* FJLiveCameraViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 871018321A841928000CEDBD /* FJLiveCameraViewController.m */; };
+		FE12FC24DB0804071032E86A /* libPods-opencv-facerec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BDDCA62108803A728EB4810 /* libPods-opencv-facerec.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1986BAD679DE6E19B4FAF424 /* Pods-opencv-facerec.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-opencv-facerec.debug.xcconfig"; path = "Pods/Target Support Files/Pods-opencv-facerec/Pods-opencv-facerec.debug.xcconfig"; sourceTree = "<group>"; };
 		47A50C0BA07F8CFD52D30073 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		6358370C65B537E4894DEFF9 /* Pods-opencv-facerec.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-opencv-facerec.release.xcconfig"; path = "Pods/Target Support Files/Pods-opencv-facerec/Pods-opencv-facerec.release.xcconfig"; sourceTree = "<group>"; };
 		70A5E7535BA0C31A438E84CE /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8710181E1A841928000CEDBD /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		8710181F1A841928000CEDBD /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -46,6 +48,7 @@
 		871018311A841928000CEDBD /* FJLiveCameraViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FJLiveCameraViewController.h; sourceTree = "<group>"; };
 		871018321A841928000CEDBD /* FJLiveCameraViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FJLiveCameraViewController.m; sourceTree = "<group>"; };
 		872C48E71A69251A001BD610 /* opencv-facerec.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "opencv-facerec.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BDDCA62108803A728EB4810 /* libPods-opencv-facerec.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-opencv-facerec.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF45A0F0FD4B4534D50EC770 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -54,7 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B3EDF519E0775A91EF5568C /* libPods.a in Frameworks */,
+				FE12FC24DB0804071032E86A /* libPods-opencv-facerec.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +68,7 @@
 			isa = PBXGroup;
 			children = (
 				70A5E7535BA0C31A438E84CE /* libPods.a */,
+				8BDDCA62108803A728EB4810 /* libPods-opencv-facerec.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -150,6 +154,8 @@
 			children = (
 				EF45A0F0FD4B4534D50EC770 /* Pods.debug.xcconfig */,
 				47A50C0BA07F8CFD52D30073 /* Pods.release.xcconfig */,
+				1986BAD679DE6E19B4FAF424 /* Pods-opencv-facerec.debug.xcconfig */,
+				6358370C65B537E4894DEFF9 /* Pods-opencv-facerec.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -161,12 +167,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 872C490A1A69251A001BD610 /* Build configuration list for PBXNativeTarget "opencv-facerec" */;
 			buildPhases = (
-				6835256A8A6D20DEF06BF770 /* Check Pods Manifest.lock */,
+				6835256A8A6D20DEF06BF770 /* [CP] Check Pods Manifest.lock */,
 				872C48E31A69251A001BD610 /* Sources */,
 				872C48E41A69251A001BD610 /* Frameworks */,
 				872C48E51A69251A001BD610 /* Resources */,
-				F570683AB5E35E7AE533C528 /* Copy Pods Resources */,
-				3CF3BFE0E730E6E0711F1DBF /* Embed Pods Frameworks */,
+				F570683AB5E35E7AE533C528 /* [CP] Copy Pods Resources */,
+				3CF3BFE0E730E6E0711F1DBF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -227,29 +233,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3CF3BFE0E730E6E0711F1DBF /* Embed Pods Frameworks */ = {
+		3CF3BFE0E730E6E0711F1DBF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-opencv-facerec/Pods-opencv-facerec-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6835256A8A6D20DEF06BF770 /* Check Pods Manifest.lock */ = {
+		6835256A8A6D20DEF06BF770 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -257,19 +263,19 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		F570683AB5E35E7AE533C528 /* Copy Pods Resources */ = {
+		F570683AB5E35E7AE533C528 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-opencv-facerec/Pods-opencv-facerec-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -391,7 +397,7 @@
 		};
 		872C490B1A69251A001BD610 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF45A0F0FD4B4534D50EC770 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 1986BAD679DE6E19B4FAF424 /* Pods-opencv-facerec.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/FaceRec/Info.plist";
@@ -402,7 +408,7 @@
 		};
 		872C490C1A69251A001BD610 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47A50C0BA07F8CFD52D30073 /* Pods.release.xcconfig */;
+			baseConfigurationReference = 6358370C65B537E4894DEFF9 /* Pods-opencv-facerec.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/FaceRec/Info.plist";


### PR DESCRIPTION
Hi, 

Thanks for your good example code! 

I tried it with cocoapods 1.0.1, and failed to compile. The problem is that cocoapods 1.x needs target for all pod libraries. So, I add target block in Podfile. And with this change, I have to remove lib-Pods.a because generated libPods-opencv-facerec.a replaces its position - I just remove lib-Pods.a from **Linked Framework and Libraries**.
